### PR TITLE
Fix crashes when a booking has no date

### DIFF
--- a/src/bank_statement_reader/booking/booking_base.py
+++ b/src/bank_statement_reader/booking/booking_base.py
@@ -281,14 +281,19 @@ class BookingBase:
     def __lt__(self, other: "BookingBase"):
         if not isinstance(other, BookingBase):
             raise ValueError("Can only compare BookingBase to other BookingBase object")
-        if self.date == other.date:
-            if self.payee == other.payee:
-                # everything is equal, lets compare comment
-                return humansorted([self.comment, other.comment])[0] == self.comment
-            else:
-                return humansorted([self.payee, other.payee])[0] == self.comment
-        else:
+        # Treat None dates as less than any real date
+        if self.date is None and other.date is None:
+            pass  # fall through to payee/comment comparison
+        elif self.date is None:
+            return True
+        elif other.date is None:
+            return False
+        elif self.date != other.date:
             return self.date < other.date
+        if self.payee == other.payee:
+            return humansorted([self.comment, other.comment])[0] == self.comment
+        else:
+            return humansorted([self.payee, other.payee])[0] == self.payee
 
     @property
     def _tr_(self):

--- a/src/bank_statement_reader/bookings.py
+++ b/src/bank_statement_reader/bookings.py
@@ -59,11 +59,11 @@ class Bookings(list):
 
     @property
     def start_date(self):
-        return list(sorted(self.daterelation.keys()))[0]
+        return list(sorted(k for k in self.daterelation.keys() if k is not None))[0]
 
     @property
     def end_date(self):
-        return list(sorted(self.daterelation.keys()))[-1]
+        return list(sorted(k for k in self.daterelation.keys() if k is not None))[-1]
 
     @property
     def sum(self):
@@ -111,6 +111,8 @@ class Bookings(list):
             fp.write("Date;Category;Type;Amount;Payee;Comment\n")
             for i in self:
                 i: Booking
+                if i.date is None:
+                    continue
                 if i.date > end_date:
                     break
                 if i.date >= start_date:


### PR DESCRIPTION
Guard __lt__, start_date, end_date, and the save loop against None dates so statement2csv no longer crashes on partially-parsed PDFs. Also fix a secondary bug in __lt__ where payees were compared against self.comment instead of self.payee.

The following changes were necessary in order for me to be able to convert GLS Bank statements from 2025 and 2026.